### PR TITLE
fix: frontend route was undefined

### DIFF
--- a/js/src/forum/addProfilePane.ts
+++ b/js/src/forum/addProfilePane.ts
@@ -3,23 +3,11 @@ import app from 'flarum/forum/app';
 import { extend } from 'flarum/common/extend';
 import LinkButton from 'flarum/common/components/LinkButton';
 import UserPage from 'flarum/forum/components/UserPage';
-import RootMasqueradePane from './panes/RootMasqueradePane';
 
 import type ItemList from 'flarum/common/utils/ItemList';
 import type Mithril from 'mithril';
 
 export default function addProfilePane() {
-  app.routes['fof-masquerade'] = {
-    path: '/u/:username/masquerade',
-    resolver: {
-      onmatch() {
-        if (!app.forum.attribute('canViewMasquerade')) throw new Error();
-
-        return RootMasqueradePane;
-      },
-    },
-  };
-
   extend(UserPage.prototype, 'navItems', function (items: ItemList<Mithril.Children>) {
     if (app.forum.attribute<boolean>('canViewMasquerade') || this.user?.canEditMasqueradeProfile()) {
       const edit = this.user?.canEditMasqueradeProfile();

--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -2,11 +2,15 @@ import Extend from 'flarum/common/extenders';
 import User from 'flarum/common/models/User';
 import Field from '../lib/models/Field';
 import Answer from '../lib/models/Answer';
+import RootMasqueradePane from './panes/RootMasqueradePane';
 
 import { default as commonExtend } from '../common/extend';
 
 export default [
   ...commonExtend,
+
+  new Extend.Routes() //
+    .add('fof-masquerade', '/u/:username/masquerade', RootMasqueradePane),
 
   new Extend.Store() //
     .add('masquerade-answer', Answer),

--- a/js/src/forum/panes/RootMasqueradePane.tsx
+++ b/js/src/forum/panes/RootMasqueradePane.tsx
@@ -1,3 +1,4 @@
+import app from 'flarum/forum/app';
 import UserPage from 'flarum/forum/components/UserPage';
 import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
 import ProfilePane from './ProfilePane';
@@ -11,6 +12,10 @@ export default class RootMasqueradePane extends UserPage {
 
   oninit(vnode: Mithril.Vnode) {
     super.oninit(vnode);
+
+    if (!app.forum.attribute('canViewMasquerade')) {
+      m.route.set(app.route('index'));
+    }
 
     this.loadUser(m.route.param('username'));
   }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

When trying to access the frontend route using `app.current.get('routeName')`, undefined was returned due to the abnormal definition of the frontend route with the custom resolver. 

**Changes proposed in this pull request:**
This PR uses the frontend extender instead and moves the check into the component itself.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
