### PR TITLE
Quality: Fix Validation field input handler to extract value from InputEvent

### DIFF
--- a/js/src/admin/components/FieldEditModal.tsx
+++ b/js/src/admin/components/FieldEditModal.tsx
@@ -142,7 +142,7 @@ export default class FieldEditModal extends FormModal<FieldEditModalAttrs> {
           help={app.translator.trans('fof-masquerade.admin.fields.validation-help', {
             a: <a href="https://laravel.com/docs/13.x/validation#custom-validation-rules" target="_blank" />,
           })}
-          oninput={(value: string) => this.validation(value)}
+          oninput={(e: InputEvent) => this.validation((e.target as HTMLInputElement).value)}
         />,
         30
       );


### PR DESCRIPTION
## Problem

The Validation input field is incorrectly handling the input event by assigning the entire InputEvent object to the validation property instead of extracting the value from e.target.value. When the event object is coerced to a string for display, it shows "[object InputEvent]". The fix ensures the actual string value is extracted from the event target.

**Severity**: `high`
**File**: `js/src/admin/components/FieldEditModal.tsx`

## Solution

Locate the input handler for the Validation field (likely an oninput or onchange handler) and change it from passing the raw event object to extracting e.target.value. If using m.withAttr, ensure it's used correctly: `oninput: m.withAttr('value', (v) => this.validation = v)` or `oninput: (e) => this.validation = e.target.value`. Check for similar patterns in other input fields in the same component to ensure consistency.

## Changes

- `js/src/admin/components/FieldEditModal.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #99