### PR TITLE
Quality: Add frontend route guarding for forced profile completion

### DIFF
--- a/js/src/forum/extend.ts
+++ b/js/src/forum/extend.ts
@@ -3,6 +3,37 @@ import Extend from 'flarum/common/extenders';
 import User from 'flarum/common/models/User';
 import Answer from '../lib/models/Answer';
 import RootMasqueradePane from './panes/RootMasqueradePane';
+import extend from 'flarum/common/extend';
+import Application from 'flarum/common/Application';
+import app from 'flarum/forum/app';
+import m from 'mithril';
+
+function checkProfile() {
+  const user = app.session.user;
+  if (!user) return;
+
+  if (user.attribute('masqueradeProfileCompleted')) return;
+
+  if (app.current.get('routeName') === 'fof-masquerade') return;
+
+  m.route.set(app.route('fof-masquerade', { username: user.username() }));
+}
+
+function interceptApi(original: Function) {
+  return function (this: Application, options: any) {
+    const user = app.session.user;
+    if (user && !user.attribute('masqueradeProfileCompleted')) {
+      const method = (options.method || 'GET').toUpperCase();
+      if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+        return Promise.reject(new Error('Profile completion required'));
+      }
+    }
+    return original.call(this, options);
+  };
+}
+
+extend(Application.prototype, 'mount', checkProfile);
+extend(Application.prototype, 'request', interceptApi);
 
 export default [
   ...commonExtend,


### PR DESCRIPTION
## Problem

The current PHP middleware only intercepts full HTTP page loads, but Flarum is a Single Page Application (SPA) that uses AJAX for navigation. When users click internal links, the frontend handles routing via Mithril's router without hitting the backend middleware, allowing users to bypass the forced profile completion requirement. The frontend must intercept route changes and API requests to enforce the restriction consistently.

**Severity**: `high`
**File**: `js/src/forum/extend.ts`

## Solution

Extend `Application.prototype` from 'flarum/common/Application' to add route interception logic. In the extension initialization, check if `app.session.user` exists and has an attribute indicating incomplete profile (e.g., `!app.session.user.attribute('masqueradeProfileCompleted')`). If the profile is incomplete and the current route is not the profile configuration page (e.g., `'user.fof-masquerade.configure'`), redirect immediately using `m.route.set()` to the configuration page. Additionally, extend `Application.prototype.request` to block or redirect on POST/PUT/DELETE API calls that would allow creating posts or discussions while the profile remains incomplete. Example implementation: `extend(Application.prototype, 'mount', checkProfile); extend(Application.prototype, 'request', interceptApi);` where `checkProfile` verifies the attribute and redirects, and `interceptApi` rejects requests that modify data.

## Changes

- `js/src/forum/extend.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #84